### PR TITLE
feat: support path-based event links

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -162,6 +162,11 @@ app.post('/upload', upload.single('file'), async (req, res) => {
   }
 });
 
+// Serve event page for path-based URLs
+app.get('/event/:slug', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'index.html'));
+});
+
 const port = process.env.PORT || 3001;
 app.listen(port, () => {
   console.log(`PixDrop server listening on port ${port}`);

--- a/src/Admin.tsx
+++ b/src/Admin.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 
 const BACKEND_URL = import.meta.env?.VITE_API_BASE || ''
+const BASE_DOMAIN = import.meta.env?.VITE_BASE_DOMAIN || ''
 const slugify = (s: string) => s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 
 interface EventItem {
@@ -103,7 +104,17 @@ export default function Admin() {
                     <div>
                       <div className="font-medium">{ev.name}</div>
                       <div className="text-sm text-slate-600">
-                        Link: <a href={`https://${ev.slug}.pixdrop.cloud`} target="_blank" rel="noreferrer" className="text-sky-600 underline">{ev.slug}.pixdrop.cloud</a>
+                        {(() => {
+                          const url = BASE_DOMAIN
+                            ? `https://${ev.slug}.${BASE_DOMAIN}`
+                            : `https://pixdrop.cloud/event/${ev.slug}`
+                          const label = BASE_DOMAIN
+                            ? `${ev.slug}.${BASE_DOMAIN}`
+                            : `pixdrop.cloud/event/${ev.slug}`
+                          return (
+                            <>Link: <a href={url} target="_blank" rel="noreferrer" className="text-sky-600 underline">{label}</a></>
+                          )
+                        })()}
                       </div>
                       <div className="text-xs text-slate-500">Folder ID: {ev.folderId}</div>
                     </div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "rewrites": [
     { "source": "/admin", "destination": "/index.html" },
-    { "source": "/admin/(.*)", "destination": "/index.html" }
+    { "source": "/admin/(.*)", "destination": "/index.html" },
+    { "source": "/event", "destination": "/index.html" },
+    { "source": "/event/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- show path-based event links when subdomain base isn't set
- handle `/event/:slug` with server and Vercel rewrites

## Testing
- `npm test` (fails: Missing script: "test")
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a64072bb483329250b1a9f3c09d0c